### PR TITLE
Remove grpcio installation from source

### DIFF
--- a/GoogleAssistant_setup.sh
+++ b/GoogleAssistant_setup.sh
@@ -21,8 +21,6 @@ python3 -m venv env
 env/bin/python -m pip install --upgrade pip setuptools wheel
 source env/bin/activate
 
-python -m pip install --upgrade --no-binary :all:  grpcio
-
 python -m pip install --upgrade google-assistant-library
 
 python -m pip install --upgrade google-assistant-sdk[samples]


### PR DESCRIPTION
This update relates that google fixed a problem that distributed a illegal(not complient to ARMV6) grpcio binary package.

https://github.com/googlesamples/assistant-sdk-python/issues/235