### PR TITLE
add installation RPi.GPIO

### DIFF
--- a/setupAssistantControl.sh
+++ b/setupAssistantControl.sh
@@ -9,7 +9,7 @@ git clone https://github.com/Kitt-AI/snowboy.git
 sudo apt-get -y install libatlas-base-dev
 
 sudo apt-get -y  install swig3.0 python-pyaudio python3-pyaudio sox swig
-pip install pyaudio spidev posix_ipc gpiozero numpy
+pip install pyaudio spidev posix_ipc gpiozero numpy RPi.GPIO
 
 cd snowboy/swig/Python3
 make


### PR DESCRIPTION
Add : Installation of RPi.GPIO
If this package is not installed, this prototype halts when executes startAssistantControl.sh in Pi3.